### PR TITLE
Remove overriden createJSModules

### DIFF
--- a/android/src/main/java/com/avishayil/rnrestart/ReactNativeRestartPackage.java
+++ b/android/src/main/java/com/avishayil/rnrestart/ReactNativeRestartPackage.java
@@ -24,11 +24,6 @@ public class ReactNativeRestartPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return new ArrayList<>();
     }

--- a/android/src/main/java/com/avishayil/rnrestart/ReactNativeRestartPackage.java
+++ b/android/src/main/java/com/avishayil/rnrestart/ReactNativeRestartPackage.java
@@ -23,7 +23,6 @@ public class ReactNativeRestartPackage implements ReactPackage {
         return modules;
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/android/src/main/java/com/avishayil/rnrestart/ReactNativeRestartPackage.java
+++ b/android/src/main/java/com/avishayil/rnrestart/ReactNativeRestartPackage.java
@@ -24,6 +24,11 @@ public class ReactNativeRestartPackage implements ReactPackage {
     }
 
     @Override
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+        return Collections.emptyList();
+    }
+
+    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return new ArrayList<>();
     }


### PR DESCRIPTION
Since of recently in master the unused createJSModules has been removed and ReactPackage's no longer contain the definition of createJSModules. There for it must be removed in order to not yield a compile error. This is breaking change.