### PR TITLE
Fix React Native 0.47 breaking change

### DIFF
--- a/android/src/main/java/com/avishayil/rnrestart/ReactNativeRestartPackage.java
+++ b/android/src/main/java/com/avishayil/rnrestart/ReactNativeRestartPackage.java
@@ -24,11 +24,6 @@ public class ReactNativeRestartPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return new ArrayList<>();
     }


### PR DESCRIPTION
Fix React Native 0.47 breaking change to remove unused `createJSModules` calls.

It was causing a crash.

Take a look at the [release notes](https://github.com/facebook/react-native/releases/tag/v0.47.0).