### PR TITLE
Deprecated createJSModules on Android only for RN >= 0.47

### DIFF
--- a/android/src/main/java/com/avishayil/rnrestart/ReactNativeRestartPackage.java
+++ b/android/src/main/java/com/avishayil/rnrestart/ReactNativeRestartPackage.java
@@ -22,7 +22,8 @@ public class ReactNativeRestartPackage implements ReactPackage {
         modules.add(new ReactNativeRestart(reactContext));
         return modules;
     }
-
+    
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
`createJSModules` is now not required on Android from RN 0.47. This is backwards compatible according to my tests, while https://github.com/avishayil/react-native-restart/pull/17 isn't.