### PR TITLE
Make sure restarting the app happen in main thread

### DIFF
--- a/ios/RCTRestart/RCTRestart.m
+++ b/ios/RCTRestart/RCTRestart.m
@@ -17,7 +17,13 @@ RCT_EXPORT_MODULE(RNRestart)
 }
 
 RCT_EXPORT_METHOD(Restart) {
-    [self loadBundle];
+    if ([NSThread isMainThread]) {
+        [self loadBundle];
+    } else {
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            [self loadBundle];
+        });
+    }
     return;
 }
 


### PR DESCRIPTION
Make sure restarting the app happen in main thread in IOS & fix ('accessing _cachedSystemAnimationFence requires the main thread' was thrown while invoking Restart on target RNRestart with params) exception