### PR TITLE
upgrade gradle to 3.2.1 and added google() as a repository

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,10 +1,11 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.2.1'
     }
 }
 


### PR DESCRIPTION
This closes #55 by upgrading gradle to 3.2.1 and adding google() repository.