### PR TITLE
Update Gradle file for support Impremetation command

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,6 +30,6 @@ android {
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.facebook.react:react-native:+'
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    implementation 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
@avishayil Your repository is very useful for my project but at this time the android must be change about the gradle command so
"compile"  command in this gradle have been deprecate at end of 2018 can i update this to implementation?

Thanks.