### PR TITLE
Revert spec name to 'RCTRestart'

### DIFF
--- a/RCTRestart.podspec
+++ b/RCTRestart.podspec
@@ -3,7 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name         = package['name']
+  s.name         = 'RCTRestart'
   s.version      = package['version']
   s.summary      = package['description']
   s.license      = { :type => package['license'], :file => 'LICENSE' }


### PR DESCRIPTION
According to [this feedback](https://github.com/avishayil/react-native-restart/commit/177541e8bb148e7a157a5a2c2648719fc5fd5c06#commitcomment-37323053), using `package['name']` causes failing `install pod` command. so I revert it to `RCTRestart`