### PR TITLE
fix: catch throwable instead of exception in restartmodule.java

### DIFF
--- a/android/src/main/java/com/reactnativerestart/RestartModule.java
+++ b/android/src/main/java/com/reactnativerestart/RestartModule.java
@@ -48,13 +48,13 @@ public class RestartModule extends ReactContextBaseJavaModule {
                 public void run() {
                     try {
                         instanceManager.recreateReactContextInBackground();
-                    } catch (Exception e) {
+                    } catch (Throwable t) {
                         loadBundleLegacy();
                     }
                 }
             });
 
-        } catch (Exception e) {
+        } catch (Throwable t) {
             loadBundleLegacy();
         }
     }


### PR DESCRIPTION
This updates the try/catch blocks in RestartModule.java to catch Throwable instead of Exception to fall back to loading the legacy bundle. recreateReactContextInBackground in React Native throws an AssertionError (which is an instance of Error, not Exception), meaning that the error wasn't being caught and our app was crashing.

See https://github.com/facebook/react-native/blob/65d52a59b044b2e8f7712af5542c4649689363fa/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java#L390

Also: https://stackoverflow.com/questions/29671796/will-an-assertion-error-be-caught-by-in-a-catch-block-for-java-exception