### PR TITLE
Fix Xcode 12 compatibility

### DIFF
--- a/react-native-restart.podspec
+++ b/react-native-restart.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m}"
 
-  s.dependency "React"
+  s.dependency 'React-Core'
 end

--- a/react-native-restart.podspec
+++ b/react-native-restart.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m}"
 
-  s.dependency 'React-Core'
+  s.dependency "React-Core"
 end


### PR DESCRIPTION
Compilation fails on Xcode 12 with `Undefined symbols for architecture` errors, due to the React dependency in the podspec.

See the react-native issue here - https://github.com/facebook/react-native/issues/29633#issuecomment-694187116