### PR TITLE
Fix TypeScript import path

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Sometimes you want to reload your app bundle during app runtime. This package will allow you to do it.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
-  "types": "lib/typescript/src/index.d.ts",
+  "types": "lib/typescript/index.d.ts",
   "react-native": "src/index.tsx",
   "files": [
     "src",


### PR DESCRIPTION
Hi there, the TypeScript path in `package.json` is incorrect, causing the import to fail with `Could not find a declaration file for module 'react-native-restart'.` when used from TypeScript.

I've previously had to make this exact fix this in another library too (https://github.com/greentriangle/react-native-leveldb/pull/1), so I believe this is probably an issue with `react-native-builder-bob`. For now, this fix should solve the import issue in this library though. I will open an issue on the `react-native-builder-bob` repo too.

Thanks a lot!