### PR TITLE
feat: add relaunchApp(final boolean isKillProcess) on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ import RNRestart from 'react-native-restart'; // Import package from node module
 
 // Immediately reload the React Native Bundle
 RNRestart.Restart();
+
+// Or, relaunch the whole APP (Only Android)
+RNRestart.relaunchApp(true); // true means kill the old APP process
 ```
 
 ## Contributing

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -115,4 +115,5 @@ repositories {
 
 dependencies {
   api 'com.facebook.react:react-native:+'
+  api 'com.blankj:utilcodex:1.31.0'
 }

--- a/android/src/main/java/com/reactnativerestart/RestartModule.java
+++ b/android/src/main/java/com/reactnativerestart/RestartModule.java
@@ -10,6 +10,8 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 
+import com.blankj.utilcode.util.AppUtils;
+
 public class RestartModule extends ReactContextBaseJavaModule {
 
     private static final String REACT_APPLICATION_CLASS_NAME = "com.facebook.react.ReactApplication";
@@ -101,6 +103,11 @@ public class RestartModule extends ReactContextBaseJavaModule {
     @Override
     public String getName() {
         return "RNRestart";
+    }
+
+    @ReactMethod
+    public void relaunchApp(final boolean isKillProcess) {
+        AppUtils.relaunchApp(isKillProcess);
     }
 
 }


### PR DESCRIPTION
I found `Restart()` React Native Bundle several times, some JS or Java memory not free enough, so comes the `relaunchApp()` the whole APP :stuck_out_tongue_closed_eyes: 