### PR TITLE
fix(android): update process phoenix dependancy

### DIFF
--- a/Example/android/app/src/main/AndroidManifest.xml
+++ b/Example/android/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
       android:name=".MainApplication"
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
+      android:banner="@mipmap/ic_launcher"
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
       android:theme="@style/AppTheme">
@@ -19,6 +20,7 @@
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />
+            <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
         </intent-filter>
       </activity>
     </application>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -117,5 +117,5 @@ repositories {
 
 dependencies {
   api 'com.facebook.react:react-native:+'
-  implementation 'com.jakewharton:process-phoenix:2.1.2'
+  implementation 'com.jakewharton:process-phoenix:2.2.0'
 }


### PR DESCRIPTION
fix(android): update process phoenix dependancy

process phoenix was not supporting android tv correctly.
This pull request upgrade process phoenix which includes an android tv patch (restart the LEANBACK_LAUNCHER activity instead of LAUNCHER activity on android)

In order to test the change I also update the sample to support android tv devices 

Will fix following ticket : https://github.com/avishayil/react-native-restart/issues/253