### PR TITLE
fix: don't pack unnecessary files

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,11 @@
     "src",
     "lib",
     "android",
+    "!android/build/",
+    "!android/.gradle/",
     "ios",
+    "!ios/Restart.xcodeproj/",
+    "!ios/Restart.xcworkspace/",
     "react-native-restart.podspec",
     "windows"
   ],


### PR DESCRIPTION
sorry, didn't mean to create this PR from the fork's master branch, replaced by https://github.com/avishayil/react-native-restart/pull/283

hey @avishayil , thanks for the lib!

currently it's packing all kinds of build files, including fat android/build/ and android/.gradle dirs, which aren't necessary for the library to work. This PR removes them from the packing list