### PR TITLE
fix(android): restore hard restart behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,10 +156,19 @@ Remember to run `cd ios && pod install` to update files used by Xcode.
 ```javascript
 import RNRestart from 'react-native-restart'; // Import package from node modules
 
-// Immediately reload the React Native Bundle
+// Restart the application
 RNRestart.Restart(); // Deprecated
 RNRestart.restart();
+
+// Optionally make a reason available after the restart
+RNRestart.restart('language-change');
+const reason = await RNRestart.getReason();
 ```
+
+On Android, `restart()` restarts the application process so both native state
+and the JavaScript runtime are reinitialized. On iOS, it reloads the React
+Native bundle. The optional restart reason survives the Android process restart
+and is returned by `getReason()` after the application starts again.
 
 ## Contributing
 

--- a/android/src/main/java/com/reactnativerestart/RestartModule.java
+++ b/android/src/main/java/com/reactnativerestart/RestartModule.java
@@ -1,123 +1,74 @@
 package com.reactnativerestart;
 
-import android.app.Activity;
-import android.os.Handler;
-import android.os.Looper;
-import com.facebook.react.ReactApplication;
-import com.facebook.react.ReactInstanceManager;
-import com.facebook.react.bridge.LifecycleEventListener;
+import android.content.Context;
+import android.content.SharedPreferences;
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.jakewharton.processphoenix.ProcessPhoenix;
-import com.facebook.react.bridge.Promise;
-
 
 public class RestartModule extends ReactContextBaseJavaModule {
 
-    private static final String REACT_APPLICATION_CLASS_NAME = "com.facebook.react.ReactApplication";
-    private static final String REACT_NATIVE_HOST_CLASS_NAME = "com.facebook.react.ReactNativeHost";
+    private static final String PREFERENCES_NAME = "react-native-restart";
+    private static final String RESTART_REASON_KEY = "restartReason";
     private static String restartReason = null;
-
-    private LifecycleEventListener mLifecycleEventListener = null;
+    private static boolean restartReasonInitialized = false;
 
     public RestartModule(ReactApplicationContext reactContext) {
         super(reactContext);
+        initializeRestartReason();
     }
 
-    private void loadBundleLegacy() {
-        final Activity currentActivity = getCurrentActivity();
-        if (currentActivity == null) {
+    private SharedPreferences getPreferences() {
+        return getReactApplicationContext().getSharedPreferences(
+            PREFERENCES_NAME,
+            Context.MODE_PRIVATE
+        );
+    }
+
+    private void initializeRestartReason() {
+        if (restartReasonInitialized) {
             return;
         }
 
-        currentActivity.runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                currentActivity.recreate();
-            }
-        });
+        SharedPreferences preferences = getPreferences();
+        if (preferences.contains(RESTART_REASON_KEY)) {
+            restartReason = preferences.getString(RESTART_REASON_KEY, null);
+            preferences.edit().remove(RESTART_REASON_KEY).commit();
+        }
+        restartReasonInitialized = true;
     }
 
-    private void loadBundle() {
-        clearLifecycleEventListener();
-        try {
-            final ReactInstanceManager instanceManager = resolveInstanceManager();
-            if (instanceManager == null) {
-                return;
-            }
+    private void restartApp(String reason) {
+        restartReason = reason;
+        SharedPreferences.Editor editor = getPreferences().edit();
 
-            new Handler(Looper.getMainLooper()).post(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        instanceManager.recreateReactContextInBackground();
-                    } catch (Throwable t) {
-                        loadBundleLegacy();
-                    }
-                }
-            });
-
-        } catch (Throwable t) {
-            loadBundleLegacy();
-        }
-    }
-
-    private static ReactInstanceHolder mReactInstanceHolder;
-
-    static ReactInstanceManager getReactInstanceManager() {
-        if (mReactInstanceHolder == null) {
-            return null;
-        }
-        return mReactInstanceHolder.getReactInstanceManager();
-    }
-
-    private ReactInstanceManager resolveInstanceManager() throws NoSuchFieldException, IllegalAccessException {
-        ReactInstanceManager instanceManager = getReactInstanceManager();
-        if (instanceManager != null) {
-            return instanceManager;
+        if (reason == null) {
+            editor.remove(RESTART_REASON_KEY);
+        } else {
+            editor.putString(RESTART_REASON_KEY, reason);
         }
 
-        final Activity currentActivity = getCurrentActivity();
-        if (currentActivity == null) {
-            return null;
-        }
-
-        ReactApplication reactApplication = (ReactApplication) currentActivity.getApplication();
-        instanceManager = reactApplication.getReactNativeHost().getReactInstanceManager();
-
-        return instanceManager;
-    }
-
-
-    private void clearLifecycleEventListener() {
-        if (mLifecycleEventListener != null) {
-            getReactApplicationContext().removeLifecycleEventListener(mLifecycleEventListener);
-            mLifecycleEventListener = null;
-        }
+        // ProcessPhoenix terminates the process immediately, so persist synchronously.
+        editor.commit();
+        ProcessPhoenix.triggerRebirth(getReactApplicationContext());
     }
 
     @ReactMethod
     public void Restart(String reason) {
-        restartReason = reason;
-        loadBundle();
+        restartApp(reason);
     }
 
     @ReactMethod
     public void restart(String reason) {
-        restartReason = reason;
-        loadBundle();
+        restartApp(reason);
     }
-    
+
     @ReactMethod
     public void getReason(Promise promise) {
-        try {
-            promise.resolve(restartReason);
-        } catch(Exception e) {
-            promise.reject("Create Event Error", e);
-        }
+        promise.resolve(restartReason);
     }
-    
 
     @Override
     public String getName() {

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -1,10 +1,33 @@
-/* eslint max-len: 0 */
+jest.mock("react-native", () => ({
+    NativeModules: {
+        RNRestart: {
+            Restart: jest.fn(),
+            getReason: jest.fn(),
+        },
+    },
+}));
 
-import "react-native";
-import RNRestart from "react-native-restart";
+import {NativeModules} from "react-native";
+import RNRestart from "../index";
 
-describe("test RNRestart API functions", () => {
-    it("calls the restart function", () => {
+const nativeRestart = NativeModules.RNRestart as {
+  Restart: jest.Mock;
+};
+
+describe("RNRestart", () => {
+    beforeEach(() => {
+        nativeRestart.Restart.mockClear();
+    });
+
+    it("restarts without a reason", () => {
         RNRestart.restart();
+
+        expect(nativeRestart.Restart).toHaveBeenCalledWith(null);
+    });
+
+    it("passes the restart reason to the native module", () => {
+        RNRestart.restart("language-change");
+
+        expect(nativeRestart.Restart).toHaveBeenCalledWith("language-change");
     });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import { NativeModules } from "react-native";
+import {NativeModules} from "react-native";
 
 const { RNRestart: rnRestart } = NativeModules;
 
@@ -6,18 +6,15 @@ type RestartType = {
   /**
    * @deprecated use `restart` instead
    */
-  Restart(): void;
-  restart(): void;
-  getReason(): Promise<string>;
+  Restart(reason?: string): void;
+  restart(reason?: string): void;
+  getReason(): Promise<string | null>;
 };
 
 const Restart = (reason?: string) => {
-    if (!reason) {
-        rnRestart.Restart(null);
-    } else {
-        rnRestart.Restart(reason);
-    }
+    rnRestart.Restart(reason ?? null);
 };
+
 const RNRestart: RestartType = {
     ...rnRestart,
     restart: Restart,


### PR DESCRIPTION
Android `restart()` stopped performing a real process restart in 0.0.28 and started reloading the React context instead.

That caused two regressions:

- native state was no longer reinitialized
- under the New Architecture/bridgeless mode, the fallback could recreate the Activity without resetting the JS runtime

This PR restores the previous Android behavior using `ProcessPhoenix.triggerRebirth()`. Since the whole process is restarted, it works independently of `ReactNativeHost` or `ReactHost` and supports both the legacy and New Architecture paths.

The optional restart reason is persisted before the process is terminated and restored when the application starts again, so the API introduced in 0.0.28 is preserved.

Also included:

- corrected TypeScript definitions for the optional reason
- tests verifying that the reason is passed to the native module
- documentation of the platform-specific restart behavior

Validated with Android compilation against:

- React Native 0.81.1
- React Native 0.85.3
- React Native 0.86.0

Jest, TypeScript, ESLint, and the package build also pass.

Closes #292
Closes #300
